### PR TITLE
Added a very basic preview of saved history

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+//go:embed static/*
+var staticFS embed.FS
+
+type Server struct {
+	config    *Config
+	saver     *JSONFilesHistorySaver
+	mux       *http.ServeMux
+	templates *template.Template
+}
+
+type StoredChatInfo struct {
+	ID           int64
+	Name         string
+	FirstLetters string
+	FileName     string
+}
+
+type ChatPageView struct {
+	Account  map[string]interface{}
+	Chat     StoredChatInfo
+	Messages []map[string]interface{}
+}
+
+type File struct {
+	ID   int64
+	Name string
+	Size int64
+}
+
+func (s *Server) chatsPageHandler(w http.ResponseWriter, r *http.Request) {
+	chatInfos, err := s.loadChats()
+	if err != nil {
+		log.Info("couldn't load chats: %v", err)
+		http.Error(w, "couldn't load chats", http.StatusInternalServerError)
+		return
+	}
+
+	s.renderTemplate(w, "chats.html", chatInfos)
+}
+
+func (s *Server) chatPageHandler(w http.ResponseWriter, r *http.Request, chatID int64) {
+	account, err := s.loadAccountData()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	chatInfo, err := s.loadChatByID(chatID)
+	if err != nil {
+		log.Info("couldn't load chat: %v", err)
+		http.Error(w, "couldn't load chat", http.StatusInternalServerError)
+		return
+	}
+
+	filesByIds, err := s.loadChatFiles(chatInfo)
+
+	if err != nil {
+		log.Info("couldn't load chat files: %v", err)
+		http.Error(w, "couldn't load chat files", http.StatusInternalServerError)
+		return
+	}
+
+	messages := make([]map[string]interface{}, 0, 1000)
+	chatPath := s.saver.Dirpath + "/" + chatInfo.FileName
+
+	loadResult := loadRelated(chatPath, func(t map[string]interface{}) {
+		t["__ChatFileName"] = chatInfo.FileName
+
+		id := int64(t["ID"].(float64))
+		if file, ok := filesByIds[id]; ok {
+			t["__File"] = file
+			t["__FileFullPath"] = strconv.FormatInt(file.ID, 10) + "_" + file.Name
+		}
+		messages = append(messages, t)
+	})
+
+	if loadResult != nil {
+		http.Error(
+			w,
+			fmt.Sprintf("couldn't load chat file %s: %s", chatPath, loadResult),
+			http.StatusInternalServerError,
+		)
+
+		return
+	}
+
+	s.renderTemplate(w, "chat.html", ChatPageView{Account: account, Chat: chatInfo, Messages: messages})
+}
+
+func (s *Server) loadAccountData() (map[string]interface{}, error) {
+	account := make(map[string]interface{})
+	n := 0
+	accountFPath := s.saver.accountFPath()
+
+	loadResult := loadRelated(accountFPath, func(t map[string]interface{}) {
+		account = t
+		n++
+	})
+
+	if loadResult != nil {
+		return nil, fmt.Errorf("couldn't load accounts file %s: %s", accountFPath, loadResult)
+	}
+
+	if n > 1 || n == 0 {
+		return nil, fmt.Errorf("expected only 1 line in %s, found: %d", accountFPath, n)
+	}
+
+	_, ok := account["ID"]
+	if !ok {
+		return nil, fmt.Errorf("malformed json: 'ID' attr is missing in %s", accountFPath)
+	}
+
+	firstName, _ := account["FirstName"].(string)
+	lastName, _ := account["LastName"].(string)
+
+	account["FirstLetters"] = extractFirstTwoLetters(firstName, lastName)
+
+	return account, nil
+}
+
+func extractFirstTwoLetters(firstName string, lastName string) string {
+	if firstName != "" && lastName != "" {
+		return fmt.Sprintf("%c%c", unicode.ToUpper(rune(firstName[0])), unicode.ToUpper(rune(lastName[0])))
+	}
+
+	name := ""
+
+	if firstName != "" {
+		name = firstName
+	} else {
+		name = lastName
+	}
+
+	words := strings.Fields(name)
+	if len(words) >= 2 {
+		return fmt.Sprintf("%c%c", unicode.ToUpper(rune(words[0][0])), unicode.ToUpper(rune(words[1][0])))
+	} else if len(words) == 1 {
+		return fmt.Sprintf("%c", unicode.ToUpper(rune(words[0][0])))
+	}
+	return ""
+}
+
+func (s *Server) loadChats() ([]StoredChatInfo, error) {
+	files, err := ioutil.ReadDir(s.saver.Dirpath)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't open history directory %s: %w", s.saver.Dirpath, err)
+	}
+
+	pattern := regexp.MustCompile(`^(\d+)_?(.*)$`)
+
+	var chatInfos []StoredChatInfo
+
+	for _, file := range files {
+		if !file.IsDir() {
+			matches := pattern.FindStringSubmatch(file.Name())
+			if matches != nil {
+				id, err := strconv.ParseInt(matches[1], 10, 64)
+				if err != nil {
+					log.Info("Error converting ID: %v", err)
+					continue
+				}
+				name := matches[2]
+				chatInfo := StoredChatInfo{
+					ID:           id,
+					Name:         name,
+					FirstLetters: extractFirstTwoLetters(name, ""),
+					FileName:     file.Name(),
+				}
+				chatInfos = append(chatInfos, chatInfo)
+			}
+		}
+	}
+
+	return chatInfos, nil
+}
+
+func (s *Server) loadChatByID(chatID int64) (StoredChatInfo, error) {
+	chatInfos, err := s.loadChats()
+	if err != nil {
+		return StoredChatInfo{}, err
+	}
+
+	for _, chat := range chatInfos {
+		if chat.ID == chatID {
+			return chat, nil
+		}
+	}
+
+	return StoredChatInfo{}, fmt.Errorf("chat with ID %d not found", chatID)
+}
+
+func (s *Server) loadChatFiles(chat StoredChatInfo) (map[int64]File, error) {
+	fileNamesById := make(map[int64]File)
+
+	dir := s.saver.Dirpath + "/files/" + chat.FileName
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fileNamesById, nil
+		}
+
+		return nil, fmt.Errorf("couldn't open history files directory %s: %w", dir, err)
+	}
+
+	pattern := regexp.MustCompile(`^(\d+)_?(.*)$`)
+
+	for _, file := range files {
+		if !file.IsDir() {
+			matches := pattern.FindStringSubmatch(file.Name())
+			if matches != nil {
+				id, err := strconv.ParseInt(matches[1], 10, 64)
+				if err != nil {
+					log.Info("Error converting ID: %v", err)
+					continue
+				}
+
+				fileNamesById[id] = File{
+					ID:   id,
+					Name: matches[2],
+					Size: file.Size(),
+				}
+			}
+		}
+	}
+
+	return fileNamesById, nil
+}
+
+func (s *Server) renderTemplate(w http.ResponseWriter, tmpl string, data interface{}) {
+	templates := template.New("").Funcs(template.FuncMap{
+		"formatDate": func(date interface{}) string {
+			return time.Unix(int64(date.(float64)), 0).Format("02.01.2006 15:04:05")
+		},
+		"nl2br": func(text string) template.HTML {
+			return template.HTML(strings.Replace(text, "\n", "<br>", -1))
+		},
+		"firstLetters": extractFirstTwoLetters,
+		"humanizeSize": func(b int64) string {
+			const unit = 1000
+			if b < unit {
+				return fmt.Sprintf("%d B", b)
+			}
+
+			div, exp := int64(unit), 0
+			for n := b / unit; n >= unit; n /= unit {
+				div *= unit
+				exp++
+			}
+			return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+		},
+	})
+
+	// Parse the layout and the specific template
+	templates, err := templates.ParseFS(templatesFS, "templates/layout.html", "templates/"+tmpl)
+	if err != nil {
+		log.Info("Error parsing templates: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	err = templates.ExecuteTemplate(w, "layout.html", data)
+	if err != nil {
+		log.Info("Error rendering template %s: %v", tmpl, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/chats/") {
+		parts := strings.Split(r.URL.Path, "/")
+		if len(parts) == 3 {
+			chatID, err := strconv.ParseInt(parts[2], 10, 64)
+			if err == nil {
+				s.chatPageHandler(w, r, chatID)
+				return
+			}
+		}
+	}
+
+	s.mux.ServeHTTP(w, r)
+}
+
+func serveHttp(addr string, config *Config, saver *JSONFilesHistorySaver) error {
+	server := &Server{
+		config: config,
+		saver:  saver,
+	}
+
+	mux := http.NewServeMux()
+	server.mux = mux
+	mux.Handle("/", http.RedirectHandler("/chats/", http.StatusFound))
+	mux.HandleFunc("/chats/", server.chatsPageHandler)
+
+	filesDir := http.Dir("./history/files")
+	mux.Handle("/files/", http.StripPrefix("/files/", http.FileServer(filesDir)))
+
+	staticFS, _ := fs.Sub(staticFS, "static")
+	mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
+
+	log.Info("Starting server on %s", addr)
+	if err := http.ListenAndServe(addr, server); err != nil {
+		return err
+	}
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -414,6 +414,17 @@ func dump() error {
 		os.Exit(2)
 	}
 
+	saver := &JSONFilesHistorySaver{Dirpath: config.OutDirPath}
+
+	if *httpAddr != "" {
+		if err := serveHttp(*httpAddr, config, saver); err != nil {
+			log.Error(nil, "ListenAndServe %s: %v", *httpAddr, err)
+			os.Exit(2)
+		}
+
+		return nil
+	}
+
 	// tg setup
 	tg, me, err := tgConnect(config, &tgLogHandler)
 	if err != nil {
@@ -429,7 +440,6 @@ func dump() error {
 			greenBoldf("%s (%s)", strings.TrimSpace(firstName+" "+lastName), username), me.ID)
 	}
 
-	saver := &JSONFilesHistorySaver{Dirpath: config.OutDirPath}
 	saver.SetFileRequestCallback(func(chat *Chat, file *TGFileInfo, msgID int32, mediaSource MediaFileSource) error {
 		if config.Media.Match(chat, file) == MatchTrue {
 			fpath, err := saver.MessageFileFPath(chat, msgID, file.FName, file.IndexInMsg, mediaSource)
@@ -550,13 +560,6 @@ func dump() error {
 					return merry.Wrap(err)
 				}
 			}
-		}
-	}
-
-	if *httpAddr != "" {
-		if err := serveHttp(*httpAddr, config, saver); err != nil {
-			log.Error(nil, "ListenAndServe %s: %v", *httpAddr, err)
-			os.Exit(2)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -351,6 +351,7 @@ func dump() error {
 	doAccountDump := flag.String("dump-account", "", "enable basic user information dump, use 'write' to enable dump, overriders config.dump_account")
 	doContactsDump := flag.String("dump-contacts", "", "enable contacts dump, use 'write' to enable dump, overriders config.dump_contacts")
 	doSessionsDump := flag.String("dump-sessions", "", "enable active sessions dump, use 'write' to enable dump, overriders config.dump_sessions")
+	httpAddr := flag.String("preview-http", "", "HTTP service address to browse through the dump")
 	flag.Parse()
 
 	// logging
@@ -551,6 +552,14 @@ func dump() error {
 			}
 		}
 	}
+
+	if *httpAddr != "" {
+		if err := serveHttp(*httpAddr, config, saver); err != nil {
+			log.Error(nil, "ListenAndServe %s: %v", *httpAddr, err)
+			os.Exit(2)
+		}
+	}
+
 	return nil
 }
 

--- a/static/file_icon.svg
+++ b/static/file_icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+    <path d="M0 0h48v48h-48z" fill="none"/>
+    <path d="M32 2h-24c-2.21 0-4 1.79-4 4v28h4v-28h24v-4zm6 8h-22c-2.21 0-4 1.79-4 4v28c0 2.21 1.79 4 4 4h22c2.21 0 4-1.79 4-4v-28c0-2.21-1.79-4-4-4zm0 32h-22v-28h22v28z" fill="#fff" />
+</svg>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,197 @@
+body {
+    margin: 0;
+    font: 12px/18px 'Open Sans',"Lucida Grande","Lucida Sans Unicode",Arial,Helvetica,Verdana,sans-serif;
+}
+.clearfix:after {
+    content: " ";
+    visibility: hidden;
+    display: block;
+    height: 0;
+    clear: both;
+}
+.pull_left {
+    float: left;
+}
+.pull_right {
+    float: right;
+}
+.page_wrap {
+    background-color: #ffffff;
+    color: #000000;
+}
+.page_wrap a {
+    color: #168acd;
+    text-decoration: none;
+}
+.page_wrap a:hover {
+    text-decoration: underline;
+}
+.page_header {
+    position: fixed;
+    z-index: 10;
+    background-color: #ffffff;
+    width: 100%;
+    border-bottom: 1px solid #e3e6e8;
+}
+.page_header .content {
+    width: 480px;
+    margin: 0 auto;
+    border-radius: 0 !important;
+}
+.bold {
+    color: #212121;
+    font-weight: 700;
+}
+.details {
+    color: #70777b;
+}
+.page_header .content .text {
+    padding: 24px 24px 22px 24px;
+    font-size: 22px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.page_body {
+    padding-top: 64px;
+    width: 480px;
+    margin: 0 auto;
+}
+.page_about {
+    padding: 24px 24px;
+}
+.userpic {
+    display: block;
+    border-radius: 50%;
+    overflow: hidden;
+}
+.userpic .initials {
+    display: block;
+    color: #fff;
+    text-align: center;
+    text-transform: uppercase;
+    user-select: none;
+}
+.media .fill,
+.userpic_default_out {
+    background-color: #ff5555;
+}
+.userpic_default {
+    background-color: #4f9cd9;
+}
+a.block_link {
+    display: block;
+    text-decoration: none !important;
+    border-radius: 4px;
+}
+a.block_link:hover {
+    text-decoration: none !important;
+    background-color: #f5f7f8;
+}
+.list_page .page_about {
+    padding: 16px 24px 0;
+    font-size: 11px;
+}
+.list_page .entry_list {
+    padding: 16px 0;
+}
+.list_page .entry {
+    padding: 10px 16px;
+}
+.list_page .entry .userpic .initials {
+    font-size: 18px;
+}
+.list_page .entry .body {
+    margin-left: 66px;
+}
+.list_page .entry .name {
+    padding: 4px 0 2px;
+    font-size: 14px;
+}
+.list_page .entry .subname {
+    padding-top: 4px;
+}
+.list_page .entry .details_entry {
+    padding-top: 4px;
+}
+.list_page .entry .info {
+    font-size: 11px;
+    padding-top: 5px;
+}
+.history {
+    padding: 16px 0;
+}
+.message {
+    margin: 0 -10px;
+    transition: background-color 2.0s ease;
+}
+.message .userpic .initials {
+    font-size: 16px;
+}
+.default {
+    padding: 10px;
+}
+.default .from_name {
+    color: #3892db;
+    font-weight: 700;
+    padding-bottom: 5px;
+}
+.default .from_name .details {
+    font-weight: normal;
+}
+.default .body {
+    margin-left: 60px;
+}
+.default .text {
+    word-wrap: break-word;
+    line-height: 150%;
+    unicode-bidi: plaintext;
+    text-align: start;
+}
+.default .reply_to,
+.default .media_wrap {
+    padding-bottom: 5px;
+}
+.default .media {
+    margin: 0 -10px;
+    padding: 5px 10px;
+}
+.default .media .fill,
+.default .media .thumb {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+}
+.default .media .fill {
+    background-repeat: no-repeat;
+    background-position: 12px 12px;
+    background-size: 24px 24px;
+}
+.default .media .title,
+.default .media_poll .question {
+    padding-top: 4px;
+    font-size: 14px;
+}
+.default .media .description {
+    color: #000000;
+    padding-top: 4px;
+    font-size: 13px;
+}
+.default .media .status {
+    padding-top: 4px;
+    font-size: 13px;
+}
+.default .video_file_wrap,
+.default .animated_wrap {
+    position: relative;
+}
+.default .video_file,
+.default .animated,
+.default .photo,
+.default .sticker {
+    display: block;
+}
+
+.media .fill {
+    background-image: url(/static/file_icon.svg)
+}

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,98 @@
+{{ define "title" }}Tg History Dumper exported data{{ end }}
+{{ define "header" }}{{ .Chat.Name }}{{ end }}
+
+{{ define "messageBody" }}
+    {{ if .__FileFullPath }}
+        <div class="media_wrap clearfix">
+            {{ if .Media.Photo }}
+                <a class="photo_wrap clearfix pull_left" href="/files/{{ .__ChatFileName }}/{{.__FileFullPath}}">
+                    <img class="photo" src="/files/{{ .__ChatFileName }}/{{.__FileFullPath}}" style="max-width: 260px; max-height: 260px;">
+                </a>
+            {{ else }}
+                <a class="media clearfix pull_left block_link media_file" href="/files/{{ .__ChatFileName }}/{{.__FileFullPath}}">
+                    <div class="fill pull_left">
+
+                    </div>
+
+                    <div class="body">
+                        <div class="title bold">
+                            {{ .__File.Name }}
+                        </div>
+
+                        <div class="status details">
+                            {{ .__File.Size | humanizeSize }}
+                        </div>
+                    </div>
+                </a>
+            {{ end }}
+        </div>
+    {{ end }}
+
+    {{ if .Message }}
+    <div class="text">
+        {{ .Message | nl2br }}
+    </div>
+    {{ end }}
+{{ end }}
+
+{{ define "content" }}
+<div class="page_body chat_page">
+    <div class="history">
+        {{ range .Messages }}
+            <div class="message default clearfix" id="">
+                <div class="pull_left userpic_wrap">
+                    <div class="userpic {{ if .Out }}userpic_default_out{{ else }}userpic_default{{ end }}" style="width: 42px; height: 42px">
+                        <div class="initials" style="line-height: 42px">
+                            {{ if .Out }}
+                                {{ $.Account.FirstLetters }}
+                            {{ else }}
+                                {{ $.Chat.FirstLetters }}
+                            {{ end }}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="body">
+                    <div class="pull_right date details" title="">
+                        {{ .Date | formatDate }}
+                    </div>
+
+                    <div class="from_name">
+                        {{ if .Out }}
+                            {{ $.Account.FirstName }} {{ $.Account.LastName }}
+                        {{ else }}
+                            {{ $.Chat.Name }}
+                        {{ end }}
+                    </div>
+
+                    {{ if .FwdFrom }}
+                        <div class="pull_left forwarded userpic_wrap">
+                            <div class="userpic userpic_default_out" style="width: 42px; height: 42px">
+
+                                <div class="initials" style="line-height: 42px">
+                                    {{ if .FwdFrom.FromName }}
+                                        {{ .FwdFrom.FromName | firstLetters ""}}
+                                    {{ end }}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="forwarded body">
+                            <div class="from_name">
+                                {{ .FwdFrom.FromName}} <span class="date details" title="">{{ .FwdFrom.Date | formatDate }}</span>
+                            </div>
+
+                            {{ template "messageBody" . }}
+                        </div>
+                    {{ else }}
+                        {{ template "messageBody" . }}
+                    {{ end }}
+                </div>
+            </div>
+        {{ else }}
+            No messages
+        {{ end }}
+</div>
+{{ end }}
+
+{{ template "layout.html" . }}

--- a/templates/chats.html
+++ b/templates/chats.html
@@ -1,0 +1,41 @@
+{{ define "title" }}Tg History Dumper exported data{{ end }}
+{{ define "header" }}Chats{{ end }}
+
+{{ define "content" }}
+<div class="page_body list_page">
+
+    <div class="page_about details">
+        This page lists all chats from this export.
+    </div>
+
+    <div class="entry_list">
+        {{ range . }}
+            <a class="entry block_link clearfix" href="/chats/{{ .ID }}">
+                <div class="pull_left userpic_wrap">
+                    <div class="userpic userpic_default" style="width: 48px; height: 48px">
+                        <div class="initials" style="line-height: 48px">
+                            {{ .FirstLetters }}
+                        </div>
+                    </div>
+                </div>
+
+                <div class="body">
+                    <div class="pull_right info details">
+
+                    </div>
+
+                    <div class="name bold">
+                        {{ .Name }}
+                    </div>
+                </div>
+            </a>
+        {{ else }}
+            No chats available
+        {{ end }}
+
+    </div>
+
+</div>
+{{ end }}
+
+{{ template "layout.html" . }}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{ block "title" . }}{{ end }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+
+<div class="page_wrap">
+    <div class="page_header">
+        <div class="content">
+            <div class="text bold">
+                {{ block "header" . }}{{ end }}
+            </div>
+        </div>
+    </div>
+
+    {{ block "content" . }}{{ end }}
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Hi!

I've added a very basic way to preview downloaded history and files. It still lacks support of a lot of message types but I think it would be ok to have it as a starting point and add more features in the future.

To serve the preview `-preview-http` option should be used
`./tg_history_dumper -preview-http=127.0.0.1:8080`