### PR TITLE
Treat TL_messageEntityTextUrl and TL_messageEntityUrl the same way as TL_messageEntityTextURL and TL_messageEntityURL 

### DIFF
--- a/http.go
+++ b/http.go
@@ -187,10 +187,14 @@ func applyEntities(strText string, entities []interface{}) []interface{} {
 			entClose := ""
 			isBlock := false
 			switch ent["_"] {
+			case "TL_messageEntityTextUrl":
+				fallthrough
 			case "TL_messageEntityTextURL":
 				href := addDefaultScheme(ent["URL"].(string), "http")
 				entOpen = `<a href="` + href + `" target="_blank">`
 				entClose = `</a>`
+			case "TL_messageEntityUrl":
+				fallthrough
 			case "TL_messageEntityURL":
 				entOffset := int64(ent["Offset"].(float64))
 				entLength := int64(ent["Length"].(float64))


### PR DESCRIPTION
Hi!

Browsing through a dump made with _TL_LAYER: 143 I encountered entities spelled as TL_messageEntityTextUrl and TL_messageEntityUrl instead of TL_messageEntityTextURL and TL_messageEntityURL.