### PR TITLE
Preview: better handling for users names in forwarded messages

### DIFF
--- a/preview_templates/chat.html
+++ b/preview_templates/chat.html
@@ -85,7 +85,9 @@
                             <div class="userpic userpic_default_out" style="width: 42px; height: 42px">
 
                                 <div class="initials" style="line-height: 42px">
-                                    {{ if .FwdFrom.FromName }}
+                                    {{ if or .__FwdFromFirstName .__FwdFromLastName }}
+                                        {{ firstLetters .__FwdFromFirstName .__FwdFromLastName }}
+                                    {{ else if .FwdFrom.FromName }}
                                         {{ .FwdFrom.FromName | firstLetters ""}}
                                     {{ end }}
                                 </div>
@@ -94,7 +96,12 @@
 
                         <div class="forwarded body">
                             <div class="from_name">
-                                {{ .FwdFrom.FromName}} <span class="date details" title="">{{ .FwdFrom.Date | formatDate }}</span>
+                                {{ if or .__FwdFromFirstName .__FwdFromLastName }}
+                                    {{ .__FwdFromFirstName }} {{ .__FwdFromLastName }}
+                                {{ else }}
+                                    {{ .FwdFrom.FromName}}
+                                {{ end }}
+                                <span class="date details" title="">{{ .FwdFrom.Date | formatDate }}</span>
                             </div>
 
                             {{ template "messageBody" . }}


### PR DESCRIPTION
Hi!

Currently only forwarded messages with FromName field being non-empty are displayed with the author name. However some forwarded messages have FromID filled instead of FromName. (with the latter being empty)
I've added handling of FromID for FwdFrom field.