### PR TITLE
Preview: add simple pagination for huge chats

### DIFF
--- a/preview_static/style.css
+++ b/preview_static/style.css
@@ -232,6 +232,12 @@ a.block_link:hover {
     display: block;
 }
 
+.pagination {
+    text-align: center;
+    padding: 20px;
+    font-size: 16px;
+}
+
 .media .fill {
     background-image: url(/static/file_icon.svg)
 }

--- a/preview_templates/chat.html
+++ b/preview_templates/chat.html
@@ -38,6 +38,11 @@
 {{ define "content" }}
 <div class="page_body chat_page">
     <div class="history">
+        {{ if .HasPrev }}
+            <a class="pagination block_link" href="/chats/{{ .Chat.ID }}?from={{ .Prev }}&limit={{ .Limit }}">
+                Previous messages
+            </a>
+        {{ end}}
         {{ range .Messages }}
             <div class="message {{if .__ServiceMessage}}service{{else}}default{{end}} clearfix" id="">
                 {{ if .__ServiceMessage }}
@@ -114,6 +119,12 @@
             </div>
         {{ else }}
             No messages
+        {{ end }}
+
+        {{ if .HasNext }}
+        <a class="pagination block_link" href="/chats/{{ .Chat.ID }}?from={{ .Next }}&limit={{ .Limit }}">
+            Next messages
+        </a>
         {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
Hi!

Chats containing a lot of messages are very difficult to handle for the browser especially if there are also a lot of media within the messages. 
I've added simple pagination in order to tackle this. Default limit 10000 was chosen empirically as some sort of a tradeoff, it can be overridden via "limit" GET-parameter which is kept through pagination.
Previous behaviour can be restored passing limit=0 as a GET-parameter.

Though there is a room for further optimisation to avoid parsing JSON-lines outside of current page window, it was left behind the scope of current PR.