### PR TITLE
Fix TL_messageEmpty error

### DIFF
--- a/tg.go
+++ b/tg.go
@@ -134,6 +134,8 @@ func tgGetMessageIDStampPeer(msgTL mtproto.TL) (int32, int32, mtproto.TL, error)
 		return msg.ID, msg.Date, msg.PeerID, nil
 	case mtproto.TL_messageService:
 		return msg.ID, msg.Date, msg.PeerID, nil
+	case mtproto.TL_messageEmpty:
+		return 0, 0, nil, nil
 	default:
 		return 0, 0, nil, merry.Wrap(mtproto.WrongRespError(msg))
 	}


### PR DESCRIPTION
While trying to get list of chats it  throws an exception, I fixed this error like that. It seems work right now.

Thanks.